### PR TITLE
Issue 21 fix: DeadObjectException Handling #34

### DIFF
--- a/android/src/main/kotlin/de/lschmierer/android_play_install_referrer/AndroidPlayInstallReferrerPlugin.kt
+++ b/android/src/main/kotlin/de/lschmierer/android_play_install_referrer/AndroidPlayInstallReferrerPlugin.kt
@@ -11,6 +11,8 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import kotlin.collections.ArrayList
+import android.os.DeadObjectException
+import android.util.Log
 
 
 /** AndroidPlayInstallReferrerPlugin */

--- a/android/src/main/kotlin/de/lschmierer/android_play_install_referrer/AndroidPlayInstallReferrerPlugin.kt
+++ b/android/src/main/kotlin/de/lschmierer/android_play_install_referrer/AndroidPlayInstallReferrerPlugin.kt
@@ -65,47 +65,66 @@ class AndroidPlayInstallReferrerPlugin : FlutterPlugin, MethodCallHandler {
         } else {
             pendingResults.add(result)
 
-            if(!isInstallReferrerPending) {
+            if (!isInstallReferrerPending) {
                 referrerClient = InstallReferrerClient.newBuilder(context).build()
-                referrerClient?.startConnection(object : InstallReferrerStateListener {
-                    override fun onInstallReferrerSetupFinished(responseCode: Int) {
-                        handleOnInstallReferrerSetupFinished(responseCode)
-                    }
+                try {
+                    referrerClient?.startConnection(object : InstallReferrerStateListener {
+                        override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                            handleOnInstallReferrerSetupFinished(responseCode)
+                        }
 
-                    override fun onInstallReferrerServiceDisconnected() {}
-                })
+                        override fun onInstallReferrerServiceDisconnected() {
+                            Log.w("InstallReferrer", "Service disconnected, retrying...")
+                            retryConnection()
+                        }
+                    })
+                } catch (e: DeadObjectException) {
+                    Log.e("InstallReferrer", "DeadObjectException caught: ${e.message}", e)
+                    referrerError = Pair("DEAD_OBJECT_EXCEPTION", "Service connection lost unexpectedly.")
+                    resolvePendingInstallReferrerResults()
+                }
             }
         }
     }
 
     @Synchronized
     private fun handleOnInstallReferrerSetupFinished(responseCode: Int) {
-        when (responseCode) {
-            InstallReferrerClient.InstallReferrerResponse.OK -> {
-                referrerClient?.let {
-                    referrerDetails = it.installReferrer
-                } ?: run {
-                    referrerError = Pair("BAD_STATE", "Result is null.")
+        try {
+            when (responseCode) {
+                InstallReferrerClient.InstallReferrerResponse.OK -> {
+                    referrerClient?.let {
+                        try {
+                            referrerDetails = it.installReferrer
+                        } catch (e: DeadObjectException) {
+                            Log.e("InstallReferrer", "DeadObjectException while fetching referrer: ${e.message}", e)
+                            referrerError = Pair("DEAD_OBJECT_EXCEPTION", "Service connection lost while retrieving data.")
+                        }
+                    } ?: run {
+                        referrerError = Pair("BAD_STATE", "Referrer client is null.")
+                    }
+                }
+                InstallReferrerClient.InstallReferrerResponse.SERVICE_DISCONNECTED -> {
+                    referrerError = Pair("SERVICE_DISCONNECTED", "Play Store service is not connected now.")
+                }
+                InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE -> {
+                    referrerError = Pair("SERVICE_UNAVAILABLE", "Connection couldn't be established.")
+                }
+                InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED -> {
+                    referrerError = Pair("FEATURE_NOT_SUPPORTED", "API not available on the current Play Store app.")
+                }
+                InstallReferrerClient.InstallReferrerResponse.DEVELOPER_ERROR -> {
+                    referrerError = Pair("DEVELOPER_ERROR", "General errors caused by incorrect usage.")
+                }
+                InstallReferrerClient.InstallReferrerResponse.PERMISSION_ERROR -> {
+                    referrerError = Pair("PERMISSION_ERROR", "App is not allowed to bind to the Service.")
+                }
+                else -> {
+                    referrerError = Pair("UNKNOWN_ERROR", "InstallReferrerClient returned unknown response code.")
                 }
             }
-            InstallReferrerClient.InstallReferrerResponse.SERVICE_DISCONNECTED -> {
-                referrerError = Pair("SERVICE_DISCONNECTED", "Play Store service is not connected now - potentially transient state.")
-            }
-            InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE -> {
-                referrerError = Pair("SERVICE_UNAVAILABLE", "Connection couldn't be established.")
-            }
-            InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED -> {
-                referrerError = Pair("FEATURE_NOT_SUPPORTED", "API not available on the current Play Store app.")
-            }
-            InstallReferrerClient.InstallReferrerResponse.DEVELOPER_ERROR -> {
-                referrerError = Pair("DEVELOPER_ERROR", "General errors caused by incorrect usage.")
-            }
-            InstallReferrerClient.InstallReferrerResponse.PERMISSION_ERROR -> {
-                referrerError = Pair("PERMISSION_ERROR", "App is not allowed to bind to the Service.")
-            }
-            else -> {
-                referrerError = Pair("UNKNOWN_ERROR", "InstallReferrerClient returned unknown response code.")
-            }
+        } catch (e: Exception) {
+            Log.e("InstallReferrer", "Unexpected error: ${e.message}", e)
+            referrerError = Pair("UNEXPECTED_ERROR", "An unexpected error occurred.")
         }
 
         resolvePendingInstallReferrerResults()
@@ -139,6 +158,23 @@ class AndroidPlayInstallReferrerPlugin : FlutterPlugin, MethodCallHandler {
         referrerError?.let {
             result.error(it.first, it.second, null)
             return
+        }
+    }
+
+    private fun retryConnection() {
+        try {
+            referrerClient = InstallReferrerClient.newBuilder(context).build()
+            referrerClient?.startConnection(object : InstallReferrerStateListener {
+                override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                    handleOnInstallReferrerSetupFinished(responseCode)
+                }
+
+                override fun onInstallReferrerServiceDisconnected() {
+                    Log.w("InstallReferrer", "Retry failed, service disconnected again.")
+                }
+            })
+        } catch (e: Exception) {
+            Log.e("InstallReferrer", "Failed to retry connection: ${e.message}", e)
         }
     }
 }


### PR DESCRIPTION
Original Author: https://github.com/lschmierer/android_play_install_referrer/pull/34

DeadObjectException Handling:

Added try-catch blocks around areas where DeadObjectException might occur, particularly during the service connection and data retrieval. Service Disconnection Recovery:

Implemented a retryConnection method to attempt reconnecting when the service gets disconnected. Logging:

Added detailed logging to track errors and retries, which can help diagnose issues during runtime. Graceful Failure:

Ensured the app handles all exceptions gracefully, setting appropriate error messages without crashing. This approach makes your app more resilient to transient service issues and ensures users aren't impacted by unexpected crashes.